### PR TITLE
Implement Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+lanuage: python
+python:
+    - "2.7"
+install:
+    - pip install --user pelican markdown
+script:
+    - pelican
+deploy:
+    provider: pages
+    github_token: $GITHUB_TOKEN
+    skip_cleanup: true
+    local_dir: output
+    on:
+        branch: master


### PR DESCRIPTION
Considering the possible issues of version skew mentioned in #3, I propose using Travis-CI to generate the output contents automatically and push to the desired branch. This could be the gh-pages branch if you want to use GitHub's hosting, or any branch if you set up your hosting machine to poll for pull changes to a specific branch. (Of course, the latter could also perform the pelican rendering itself too, but this gives a degree of public visibility of build success ;-) )