### PR TITLE
Change the Calendar link to go to our Meetup page

### DIFF
--- a/content/pages/Calendar.md
+++ b/content/pages/Calendar.md
@@ -1,9 +1,5 @@
-Title: Calendar
-Date: June 29, 2017
-Author: JustBill
-
 Calendar
-======
-<dl>
-<dd><iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=info%40interlockroc.org&amp;color=%23125A12&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe><dd>
-</dl>
+######
+:slug: calendar
+:title: Calendar
+:link: https://www.meetup.com/Interlock-Rochester-Hackerspace/


### PR DESCRIPTION
This is one way to "sync" these pages, I guess...

Issue #26 or whatever